### PR TITLE
Payloads revised for dialogflow-fulfillment

### DIFF
--- a/src/v1-agent.js
+++ b/src/v1-agent.js
@@ -176,6 +176,28 @@ class V1Agent {
   }
 
   /**
+   * Send v1 response to Dialogflow fulfillment webhook request based on developer
+   * defined response messages and payloads
+   *
+   * @param {Array} payloads
+   * @param {string} requestSource string indicating the source of the initial request
+   * @private
+   */
+  sendPayloadsAndMessagesResponse_(payloads, requestSource) {
+    const data = {};
+    payloads.forEach((payload) => {
+      if (payload.platform) {
+        Object.assign(data, payload.getPayload_(payload.platform));
+      }
+    });
+
+    this.sendJson_({
+      messages: this.buildResponseMessages_(requestSource),
+      data,
+    });
+  }
+
+  /**
    * Send v1 response to Dialogflow fulfillment webhook request
    *
    * @param {Object} responseJson JSON to send to Dialogflow

--- a/src/v2-agent.js
+++ b/src/v2-agent.js
@@ -195,6 +195,28 @@ class V2Agent {
   }
 
   /**
+   * Send v2 response to Dialogflow fulfillment webhook request based on developer
+   * defined response messages and payloads
+   *
+   * @param {Array} payloads
+   * @param {string} requestSource string indicating the source of the initial request
+   * @private
+   */
+  sendPayloadsAndMessagesResponse_(payloads, requestSource) {
+    const payload = {};
+    payloads.forEach((p) => {
+      if (p.platform) {
+        Object.assign(payload, p.getPayload_(p.platform));
+      }
+    });
+
+    this.sendJson_({
+      fulfillmentMessages: this.buildResponseMessages_(requestSource),
+      payload,
+    });
+  }
+
+  /**
    * Send v2 response to Dialogflow fulfillment webhook request
    *
    * @param {Object} responseJson JSON to send to Dialogflow


### PR DESCRIPTION
### Description
- Enables sending platform specific payloads along with custom payloads.
- Enables sending payloads and messages.

### Solution
- Grab all payloads from responses and if they exist, send not just the messages/fulfillmentMessages but also all the payloads.

### Example (for Facebook)
Send media attachment:
```
const payload = new Payload('media_attachment', { type: 'image', url: 'https://fake.images.com/123' });
agent.add(payload);
```

Send button to open a webview as wel
```
const buttonTemplate = {...};
const payload = new Payload(agent.FACEBOOK, buttonTemplate);
agent.add(payload);
```
